### PR TITLE
Export changes and fixes. 

### DIFF
--- a/hydrobot/data_sources.py
+++ b/hydrobot/data_sources.py
@@ -1,6 +1,5 @@
 """Handling for different types of data sources."""
 import csv
-import re
 from pathlib import Path
 
 import numpy as np
@@ -198,11 +197,7 @@ def get_qc_evaluator(qc_evaluator_name):
 
 def series_export_to_csv(
     file_location: str,
-    site_name: str,
-    measurement_name: str,
-    std_series: pd.Series | None,
-    check_series: pd.Series | None,
-    qc_series: pd.Series | None,
+    series: list[pd.Series],
 ) -> None:
     """Export the 3 main series to csv.
 
@@ -210,48 +205,15 @@ def series_export_to_csv(
     ----------
     file_location : str
         Where the files are exported to
-    site_name : str
-        Site name
-    measurement_name : str
-        Measurement name
-    std_series : pd.Series
-        Standard series
-    check_series : pd.Series
-        Check series
-    qc_series : pd.Series
-        Quality code series
+    series : pd.Series
+        Pandas series to be exported
 
     Returns
     -------
     None, but makes files
     """
-    if std_series is not None:
-        std_series.to_csv(
-            str(file_location)
-            + "std_"
-            + site_name
-            + "-"
-            + re.sub("[^A-Za-z0-9]+", "_", measurement_name)
-            + ".csv"
-        )
-    if check_series is not None:
-        check_series.to_csv(
-            str(file_location)
-            + "check_"
-            + site_name
-            + "-"
-            + re.sub("[^A-Za-z0-9]+", "_", measurement_name)
-            + ".csv"
-        )
-    if qc_series is not None:
-        qc_series.to_csv(
-            str(file_location)
-            + "QC_"
-            + site_name
-            + "-"
-            + re.sub("[^A-Za-z0-9]+", "_", measurement_name)
-            + ".csv"
-        )
+    export_df = pd.DataFrame(series).T
+    export_df.to_csv(str(file_location))
 
 
 def hilltop_export(
@@ -284,18 +246,14 @@ def hilltop_export(
     -------
     None, but makes files
     """
+    print("On our way out (std):", std_series.index)
+    print("On our way out (qual):", qc_series.index)
     qc_series = qc_series.reindex(std_series.index, method="ffill")
+    print("Why would this not work?", qc_series.index)
     std_series.name = "std"
     qc_series.name = "qual"
     export_df = std_series.to_frame().join(qc_series)
-    export_df.to_csv(
-        str(file_location)
-        + "hilltop_combined_std_QC_"
-        + site_name
-        + "-"
-        + re.sub("[^A-Za-z0-9]+", "_", measurement_name)
-        + ".csv"
-    )
+    export_df.to_csv(str(file_location) + "_std_qc.csv")
 
     keys = [
         "Sitename",
@@ -324,11 +282,5 @@ def hilltop_export(
         axis=1,
         keys=keys,
     )
-    export_check_df.to_csv(
-        str(file_location)
-        + "hilltop_check_import_"
-        + site_name
-        + "-"
-        + re.sub("[^A-Za-z0-9]+", "_", measurement_name)
-        + ".csv"
-    )
+
+    export_check_df.to_csv(str(file_location) + "_check.csv")

--- a/hydrobot/processor.py
+++ b/hydrobot/processor.py
@@ -193,17 +193,15 @@ class Processor:
         self._no_data = True
         self._standard_series = pd.Series({})
         self._check_series = pd.Series({})
-        self._check_data = pd.DataFrame({})
         self._quality_series = pd.Series({})
 
-        self.raw_standard_series = None
+        self.raw_standard_series = pd.Series({})
         self.raw_standard_blob = None
         self.raw_standard_xml = None
-        self.raw_quality_series = None
+        self.raw_quality_series = pd.Series({})
         self.raw_quality_blob = None
         self.raw_quality_xml = None
-        self.raw_check_data = None
-        self.raw_check_series = None
+        self.raw_check_data = pd.DataFrame({})
         self.raw_check_blob = None
         self.raw_check_xml = None
 
@@ -309,16 +307,6 @@ class Processor:
         self._standard_series = value
 
     @property
-    def check_data(self):  # type: ignore
-        """pd.DataFrame: The DataFrame containing check data."""
-        return self._check_data
-
-    @check_data.setter
-    def check_data(self, value):
-        self._check_data = value
-        self._check_series = self._check_data[self.check_item_name]
-
-    @property
     def check_series(self):  # type: ignore
         """pd.Series: The series containing check data."""
         return self._check_series
@@ -327,7 +315,6 @@ class Processor:
     @check_series.setter
     def check_series(self, value):
         self._check_series = value
-        self._check_data[self.check_item_name] = value
 
     @property
     def quality_series(self):  # type: ignore
@@ -349,7 +336,6 @@ class Processor:
         self,
         from_date: str | None = None,
         to_date: str | None = None,
-        overwrite: bool = False,
     ):
         """
         Import standard data.
@@ -362,10 +348,6 @@ class Processor:
         to_date : str or None, optional
             The end date for data retrieval. If None, defaults to latest available
             data.
-        overwrite : bool, optional
-            If True, overwrite existing data with newly acquired data for overlapping
-            timestamps. If False, keep existing data and only add new datapoints if
-            they don't already exist.
 
         Returns
         -------
@@ -398,7 +380,7 @@ class Processor:
         --------
         >>> processor = Processor(...)  # initialize processor instance
         >>> processor.import_standard(
-        ...     from_date='2022-01-01', to_date='2022-01-10', overwrite=True
+        ...     from_date='2022-01-01', to_date='2022-01-10'
         ... )
         """
         xml_tree, blob_list = data_acquisition.get_data(
@@ -411,26 +393,6 @@ class Processor:
             tstype="Standard",
         )
 
-        if (
-            isinstance(self._standard_series, pd.Series)
-            and not self._standard_series.empty
-        ):
-            warnings.warn(
-                "Just letting you know that you're overwriting the raw data."
-                " I couldn't figure out how else to do this."
-                " I can probably do it but I have other things to do right now."
-                " TODO: Remove unprofessional warnings from code.",
-                stacklevel=1,
-            )
-            curr_series = self._standard_series
-        else:
-            warnings.warn(
-                "Existing Standard Series should be pandas.Series, but found "
-                f"{type(self._standard_series)}. Setting to empty pd.Series",
-                stacklevel=1,
-            )
-            curr_series = pd.Series({})
-        insert_series = pd.Series({})
         blob_found = False
 
         date_format = "Calendar"
@@ -446,14 +408,13 @@ class Processor:
                 if (blob.data_source.name == self._standard_measurement_name) and (
                     blob.data_source.ts_type == "StdSeries"
                 ):
-                    insert_series = blob.data.timeseries
+                    self.raw_standard_series = blob.data.timeseries
                     date_format = blob.data.date_format
-                    if insert_series is not None:
+                    if self.raw_standard_series is not None:
                         # Found it. Now we extract it.
                         blob_found = True
                         self.raw_standard_blob = blob
                         self.raw_standard_xml = xml_tree
-                        self.raw_standard_series = insert_series
             if not blob_found:
                 raise ValueError(
                     f"Standard Data Not Found under name "
@@ -461,34 +422,23 @@ class Processor:
                     f"Available data sources are: {data_source_list}"
                 )
 
-            if not isinstance(insert_series, pd.Series):
+            if not isinstance(self.raw_standard_series, pd.Series):
                 raise TypeError(
-                    f"Expecting pd.Series for Standard data, but got {type(insert_series)}"
+                    f"Expecting pd.Series for Standard data, but got {type(self.raw_standard_series)}"
                     "from parser."
                 )
-            if not insert_series.empty:
+            if not self.raw_standard_series.empty:
                 if date_format == "mowsecs":
-                    insert_series.index = utils.mowsecs_to_datetime_index(
-                        insert_series.index
+                    self.raw_standard_series.index = utils.mowsecs_to_datetime_index(
+                        self.raw_standard_series.index
                     )
                 else:
-                    insert_series.index = pd.to_datetime(insert_series.index)
-                insert_series = insert_series.asfreq(self._frequency, fill_value=np.NaN)
-            if not curr_series.empty:
-                if overwrite:
-                    # Combine, but overwrite overlapping timestamps with newly acquired
-                    # data
-                    self._standard_series = insert_series.combine_first(
-                        curr_series
-                    ).sort_index()
-                else:
-                    # Combine, keeping all existing values and only adding new datapoints
-                    # if they don't already exist.
-                    self._standard_series = curr_series.combine_first(
-                        insert_series
-                    ).sort_index()
-            else:
-                self._standard_series = insert_series
+                    self.raw_standard_series.index = pd.to_datetime(
+                        self.raw_standard_series.index
+                    )
+                self.raw_standard_series = self.raw_standard_series.asfreq(
+                    self._frequency, fill_value=np.NaN
+                )
             if self.raw_standard_blob is not None:
                 fmt = self.raw_standard_blob.data_source.item_info[0].item_format
                 div = self.raw_standard_blob.data_source.item_info[0].divisor
@@ -503,25 +453,26 @@ class Processor:
             if div is None or div == "None":
                 div = 1
             if fmt == "I":
-                self.standard_series = self._standard_series.astype(int) / int(div)
-            elif fmt == "F":
-                self.standard_series = self._standard_series.astype(np.float32) / float(
+                self.raw_standard_series = self.raw_standard_series.astype(int) / int(
                     div
                 )
+            elif fmt == "F":
+                self.raw_standard_series = self.raw_standard_series.astype(
+                    np.float32
+                ) / float(div)
             elif fmt == "D":  # Not sure if this would ever really happen, but...
-                self.standard_series = utils.mowsecs_to_datetime_index(
-                    self._standard_series
+                self.raw_standard_series = utils.mowsecs_to_datetime_index(
+                    self.raw_standard_series
                 )
             else:
                 raise ValueError(f"Unknown Format Spec: {fmt}")
-            self.raw_standard_series = self._standard_series
+            self.standard_series = self.raw_standard_series
 
     @ClassLogger
     def import_quality(
         self,
         from_date: str | None = None,
         to_date: str | None = None,
-        overwrite: bool = False,
     ):
         """
         Import quality data.
@@ -534,11 +485,6 @@ class Processor:
         to_date : str or None, optional
             The end date for data retrieval. If None, defaults to latest available
             data.
-        overwrite : bool, optional
-            If True, overwrite existing data with newly acquired data for overlapping
-            timestamps.
-            If False, keep existing data and only add new datapoints if they don't
-            already exist.
 
         Returns
         -------
@@ -581,16 +527,6 @@ class Processor:
             tstype="Quality",
         )
 
-        if isinstance(self._quality_series, pd.Series):
-            curr_series = self._quality_series
-        else:
-            warnings.warn(
-                "Existing Quality Series should be pandas.Series, but found "
-                f"{type(self._quality_series)}. Setting to empty pd.Series",
-                stacklevel=1,
-            )
-            curr_series = pd.Series({})
-        insert_series = pd.Series({})
         blob_found = False
 
         if blob_list is None or len(blob_list) == 0:
@@ -607,9 +543,9 @@ class Processor:
                     # Found it. Now we extract it.
                     blob_found = True
 
-                    insert_series = blob.data.timeseries
+                    self.raw_quality_series = blob.data.timeseries
                     date_format = blob.data.date_format
-                    if insert_series is not None:
+                    if self.raw_quality_series is not None:
                         # Found it. Now we extract it.
                         blob_found = True
                         self.raw_quality_blob = blob
@@ -620,43 +556,29 @@ class Processor:
                     stacklevel=2,
                 )
 
-            if not isinstance(insert_series, pd.Series):
+            if not isinstance(self.raw_quality_series, pd.Series):
                 raise TypeError(
                     f"Expecting pd.Series for Quality data, but got "
-                    f"{type(insert_series)} from parser."
+                    f"{type(self.raw_quality_series)} from parser."
                 )
-            if not insert_series.empty:
+            if not self.raw_quality_series.empty:
                 if date_format == "mowsecs":
-                    insert_series.index = utils.mowsecs_to_datetime_index(
-                        insert_series.index
+                    self.raw_quality_series.index = utils.mowsecs_to_datetime_index(
+                        self.raw_quality_series.index
                     )
                 else:
-                    insert_series.index = pd.to_datetime(insert_series.index)
+                    self.raw_quality_series.index = pd.to_datetime(
+                        self.raw_quality_series.index
+                    )
 
-            if not curr_series.empty:
-                if overwrite:
-                    # Combine, but overwrite overlapping timestamps with newly acquired
-                    # data
-                    self._quality_series = insert_series.combine_first(
-                        curr_series
-                    ).sort_index()
-                else:
-                    # Combine, keeping all existing values and only adding new
-                    # datapoints if they don't already exist.
-                    self._quality_series = curr_series.combine_first(
-                        insert_series
-                    ).sort_index()
-            elif not insert_series.empty:
-                self._quality_series = insert_series
-            self.quality_series = self._quality_series.astype(int)
-            self.raw_quality_series = self.quality_series.astype(int)
+            self.quality_series = self.raw_quality_series.astype(int)
+            self._quality_series.name = self._standard_measurement_name + " [Quality]"
 
     @ClassLogger
     def import_check(
         self,
         from_date: str | None = None,
         to_date: str | None = None,
-        overwrite: bool = False,
     ):
         """
         Import Check data.
@@ -669,10 +591,6 @@ class Processor:
         to_date : str or None, optional
             The end date for data retrieval. If None, defaults to latest available
             data.
-        overwrite : bool, optional
-            If True, overwrite existing data with newly acquired data for overlapping
-            timestamps. If False, keep existing data and only add new datapoints if
-            they don't already exist.
 
         Returns
         -------
@@ -694,9 +612,8 @@ class Processor:
         Notes
         -----
         This method imports Check data from the specified server based on the provided
-        parameters. It retrieves data using the `data_acquisition.get_data` function
-        and updates the Check data in the instance. The data is parsed and formatted
-        according to the item_info in the data source.
+        parameters. It retrieves data using the `data_acquisition.get_data` function.
+        The data is parsed and formatted according to the item_info in the data source.
 
         Examples
         --------
@@ -714,16 +631,7 @@ class Processor:
             to_date,
             tstype="Check",
         )
-        if isinstance(self._check_data, pd.DataFrame):
-            curr_data = self._check_data
-        else:
-            warnings.warn(
-                "Existing Check Data should be pandas.DataFrame, but found "
-                f"{type(self._check_data)}. Setting to empty pd.DataFrame",
-                stacklevel=1,
-            )
-            curr_data = pd.DataFrame({})
-        insert_data = pd.DataFrame({})
+        import_data = pd.DataFrame({})
         blob_found = False
 
         date_format = "Calendar"
@@ -745,11 +653,11 @@ class Processor:
                     date_format = blob.data.date_format
 
                     # This could be a pd.Series
-                    insert_data = blob.data.timeseries
-                    if insert_data is not None:
+                    import_data = blob.data.timeseries
+                    if import_data is not None:
                         self.raw_check_blob = blob
                         self.raw_check_xml = xml_tree
-                        self.raw_check_data = insert_data
+                        self.raw_check_data = import_data
             if not blob_found:
                 warnings.warn(
                     f"Check data {self.check_data_source_name} not found in server "
@@ -757,67 +665,56 @@ class Processor:
                     stacklevel=2,
                 )
 
-            if not isinstance(insert_data, pd.DataFrame):
+            if not isinstance(self.raw_check_data, pd.DataFrame):
                 raise TypeError(
-                    f"Expecting pd.DataFrame for Check data, but got {type(insert_data)}"
+                    f"Expecting pd.DataFrame for Check data, but got {type(self.raw_check_data)}"
                     "from parser."
                 )
-            if not insert_data.empty:
+            if not self.raw_check_data.empty:
                 if date_format == "mowsecs":
-                    insert_data.index = utils.mowsecs_to_datetime_index(
-                        insert_data.index
+                    self.raw_check_data.index = utils.mowsecs_to_datetime_index(
+                        self.raw_check_data.index
                     )
                 else:
-                    insert_data.index = pd.to_datetime(insert_data.index)
+                    self.raw_check_data.index = pd.to_datetime(
+                        self.raw_check_data.index
+                    )
 
-            if not curr_data.empty:
-                if overwrite:
-                    # Combine, but overwrite overlapping timestamps with newly acquired
-                    # data
-                    self._check_data = insert_data.combine_first(curr_data).sort_index()
-                else:
-                    # Combine, keeping all existing values and only adding new datapoints
-                    # if they don't already exist.
-                    self._check_data = curr_data.combine_first(insert_data).sort_index()
-            elif not insert_data.empty:
-                self._check_data = insert_data
-            if not self._check_data.empty and self.raw_check_blob is not None:
+            if not self.raw_check_data.empty and self.raw_check_blob is not None:
                 # TODO: Maybe this should happen in the parser?
                 for i, item in enumerate(self.raw_check_blob.data_source.item_info):
                     fmt = item.item_format
                     div = item.divisor
-                    col = self._check_data.iloc[:, i]
+                    col = self.raw_check_data.iloc[:, i]
                     if fmt == "I":
-                        self._check_data.iloc[:, i] = col.astype(int) / int(div)
+                        self.raw_check_data.iloc[:, i] = col.astype(int) / int(div)
                     elif fmt == "F":
-                        self._check_data.iloc[:, i] = col.astype(np.float32) / float(
+                        self.raw_check_data.iloc[:, i] = col.astype(np.float32) / float(
                             div
                         )
                     elif fmt == "D":
-                        if self._check_data.iloc[:, i].dtype != pd.Timestamp:
+                        if self.raw_check_data.iloc[:, i].dtype != pd.Timestamp:
                             if date_format == "mowsecs":
-                                self._check_data.iloc[
+                                self.raw_check_data.iloc[
                                     :, i
                                 ] = utils.mowsecs_to_datetime_index(col)
                             else:
-                                self._check_data.iloc[:, i] = col.astype(pd.Timestamp)
+                                self.raw_check_data.iloc[:, i] = col.astype(
+                                    pd.Timestamp
+                                )
                     elif fmt == "S":
-                        self._check_data.iloc[:, i] = col.astype(str)
+                        self.raw_check_data.iloc[:, i] = col.astype(str)
 
-            self.check_data = self._check_data
-            self.raw_check_data = self.check_data
-            if not self._check_data.empty:
-                self.check_series = self.check_data[self.check_item_name]
-                self.raw_check_series = self.check_data[self.check_item_name]
+            if not self.raw_check_data.empty:
+                self.check_series = self.raw_check_data[self.check_item_name]
             else:
                 self.check_series = pd.Series({})
-                self.raw_check_series = pd.Series({})
+            self._check_series.name = self._standard_measurement_name + " [Check]"
 
     def import_data(
         self,
         from_date: str | None = None,
         to_date: str | None = None,
-        overwrite: bool = False,
         standard: bool = True,
         check: bool = True,
         quality: bool = True,
@@ -860,22 +757,18 @@ class Processor:
             and not self._quality_series.empty
             and self._check_series is not None
             and not self._check_series.empty
-            and self._check_data is not None
-            and not self._check_data.empty
         ):
             warnings.warn(
-                "Just letting you know that you're overwriting the raw data."
-                " I couldn't figure out how else to do this."
-                " I can probably do it but I have other things to do right now."
-                " TODO: Remove unprofessional warnings from code.",
+                "When you reimport, you are overwriting your data. You will lose all"
+                "progess up to this point.",
                 stacklevel=1,
             )
         if standard:
-            self.import_standard(from_date, to_date, overwrite)
+            self.import_standard(from_date, to_date)
         if quality:
-            self.import_quality(from_date, to_date, overwrite)
+            self.import_quality(from_date, to_date)
         if check:
-            self.import_check(from_date, to_date, overwrite)
+            self.import_check(from_date, to_date)
         self._stale = False
 
     # @stale_warning  # type: ignore
@@ -1213,9 +1106,9 @@ class Processor:
         self,
         file_location,
         ftype="xml",
-        standard=True,
-        quality=True,
-        check=False,
+        standard: bool = True,
+        quality: bool = True,
+        check: bool = False,
         trimmed=True,
     ):
         """
@@ -1224,9 +1117,13 @@ class Processor:
         Parameters
         ----------
         file_location : str
-            The file path where the file will be saved.
+            The file path where the file will be saved. If 'ftype' is "csv" or "xml",
+            this should be a full file path including extension. If 'ftype' is
+            "hilltop_csv", multiple files will be created, so 'file_location' should be
+            a prefix that will be appended with "_std_qc.csv" for the file containing
+            the standard and quality data, and "_check.csv" for the check data file.
         ftype : str, optional
-            Avalable options are "xml", "csv".
+            Avalable options are "xml", "hilltop_csv", "csv".
         trimmed : bool, optional
             If True, export trimmed data; otherwise, export the full data.
             Default is True.
@@ -1245,6 +1142,7 @@ class Processor:
         >>> processor.data_exporter("output.xml", trimmed=True)
         >>> # Check the generated XML file at 'output.xml'
         """
+        export_selections = [standard, quality, check]
         if trimmed:
             std_series = filters.trim_series(
                 self._standard_series,
@@ -1254,15 +1152,15 @@ class Processor:
             std_series = self._standard_series
 
         if ftype == "csv":
-            data_sources.series_export_to_csv(
-                file_location,
-                self._site,
-                self._quality_code_evaluator.name,
-                std_series,
-                self._check_series,
+            all_series = [
+                self._standard_series,
                 self._quality_series,
-            )
+                self._check_series,
+            ]
+            export_list = [i for (i, v) in zip(all_series, export_selections) if v]
+            data_sources.series_export_to_csv(file_location, series=export_list)
         if ftype == "hilltop_csv":
+            print("At the exporter:", self.quality_series.index.dtype)
             data_sources.hilltop_export(
                 file_location,
                 self._site,
@@ -1485,18 +1383,16 @@ class Processor:
                         f"found {type(self._quality_series)}"
                     )
             elif dtype == "check":
-                if isinstance(self._check_data, pd.DataFrame):
-                    timeseries = self._check_data
+                if isinstance(self._check_series, pd.Series):
+                    timeseries = self.raw_check_data
+                    timeseries[self.check_item_name] = self._check_series
                 else:
                     raise TypeError(
-                        "Check Data should be pd.DataFrame, "
-                        f"found {type(self._check_data)}"
+                        "Check Data should be pd.Series, "
+                        f"found {type(self._check_series)}"
                     )
             else:
                 raise ValueError("No data found for export.")
-            # timeseries.index = utils.datetime_index_to_mowsecs(
-            #     timeseries.index
-            # )
             if (
                 hasattr(raw_blob.data_source, "item_info")
                 and raw_blob.data_source.item_info is not None

--- a/hydrobot/utils.py
+++ b/hydrobot/utils.py
@@ -6,6 +6,76 @@ import pandas as pd
 MOWSECS_OFFSET = 946771200
 
 
+def mowsecs_to_timestamp(mowsecs):
+    """
+    Convert MOWSECS (Ministry of Works Seconds) index to datetime index.
+
+    Parameters
+    ----------
+    index : pd.Index
+        The input index in MOWSECS format.
+
+    Returns
+    -------
+    pd.DatetimeIndex
+        The converted datetime index.
+
+    Notes
+    -----
+    This function takes an index representing time in Ministry of Works Seconds
+    (MOWSECS) format and converts it to a pandas DatetimeIndex.
+
+    Examples
+    --------
+    >>> mowsecs_index = pd.Index([0, 1440, 2880], name="Time")
+    >>> converted_index = mowsecs_to_datetime_index(mowsecs_index)
+    >>> isinstance(converted_index, pd.DatetimeIndex)
+    True
+    """
+    try:
+        mowsec_time = int(mowsecs)
+    except ValueError as e:
+        raise TypeError("Expected something that is parseable as an integer") from e
+
+    unix_time = mowsec_time - MOWSECS_OFFSET
+    timestamp = pd.Timestamp(unix_time, unit="s")
+    return timestamp
+
+
+def timestamp_to_mowsecs(timestamp):
+    """
+    Convert MOWSECS (Ministry of Works Seconds) index to datetime index.
+
+    Parameters
+    ----------
+    index : pd.Index
+        The input index in MOWSECS format.
+
+    Returns
+    -------
+    pd.DatetimeIndex
+        The converted datetime index.
+
+    Notes
+    -----
+    This function takes an index representing time in Ministry of Works Seconds
+    (MOWSECS) format and converts it to a pandas DatetimeIndex.
+
+    Examples
+    --------
+    >>> mowsecs_index = pd.Index([0, 1440, 2880], name="Time")
+    >>> converted_index = mowsecs_to_datetime_index(mowsecs_index)
+    >>> isinstance(converted_index, pd.DatetimeIndex)
+    True
+    """
+    try:
+        timestamp = pd.Timestamp(timestamp)
+    except ValueError as e:
+        raise TypeError("Expected something that is parseable as an integer") from e
+
+    return int((timestamp.timestamp()) + MOWSECS_OFFSET)
+
+
 def mowsecs_to_datetime_index(index):
     """
     Convert MOWSECS (Ministry of Works Seconds) index to datetime index.

--- a/hydrobot/utils.py
+++ b/hydrobot/utils.py
@@ -32,7 +32,10 @@ def mowsecs_to_datetime_index(index):
     >>> isinstance(converted_index, pd.DatetimeIndex)
     True
     """
-    mowsec_time = index.astype(np.int64)
+    try:
+        mowsec_time = index.astype(np.int64)
+    except ValueError as e:
+        raise TypeError("These don't look like mowsecs. Expecting an integer.") from e
     unix_time = mowsec_time.map(lambda x: x - MOWSECS_OFFSET)
     timestamps = unix_time.map(
         lambda x: pd.Timestamp(x, unit="s") if x is not None else None

--- a/hydrobot/xml_data_structure.py
+++ b/hydrobot/xml_data_structure.py
@@ -1,5 +1,6 @@
 """DataSourceBlob Object."""
 import re
+import warnings
 from xml.etree import ElementTree
 
 import pandas as pd
@@ -808,7 +809,12 @@ def parse_xml(source) -> list[DataSourceBlob] | None:
         ElementTree.indent(root, space="\t")
         print("Hilltop xml possibly returned no data. Check for yourself:")
         ElementTree.dump(root)
-        return None
+        err_text = root.findtext("Error")
+        if "No data from " in str(err_text):
+            warnings.warn(str(err_text), stacklevel=1)
+            return None
+        else:
+            raise ValueError(err_text)
     elif root.tag != "Hilltop":
         raise ValueError(
             f"Possibly malformed Hilltop xml. Root tag is '{root.tag}',"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 requires-python = "==3.11.6"
 dependencies = [
     "hilltop-py>=2.3.1",
-    "data-annalist>=0.3.6",
+    "data-annalist>=0.4.1",
     "matplotlib>=3.8.0",
     "defusedxml>=0.7.1"
 ]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,10 +46,10 @@ def test_xml_data_structure_integration(tmp_path):
         "standard_hts_filename": "RawLogger.hts",
         "check_hts_filename": "boo.hts",
         "site": "Whanganui at Te Rewa",
-        "from_date": "2023-03-23 00:00",
-        "to_date": "2023-03-23 23:00",
+        "from_date": "2021-06-28 00:00",
+        "to_date": "2021-07-01 23:00",
         "frequency": "5T",
-        "standard_measurement_name": "Water level statistics: Point Sample",
+        "standard_measurement_name": "Stage",
         "check_measurement_name": "External S.G. [Water Level NRT]",
         "defaults": {
             "high_clip": 20000,
@@ -260,7 +260,6 @@ def test_processor_integration(tmp_path):
     )
 
     assert not data.standard_series.empty
-    assert not data.check_data.empty
     assert not data.check_series.empty
     assert not data.quality_series.empty
 
@@ -432,14 +431,13 @@ def test_empty_response(tmp_path):
     assert data.standard_series.empty
     assert data.check_series.empty
     assert data.quality_series.empty
-    assert data.raw_standard_series is None
+    assert data.raw_standard_series.empty
     assert data.raw_standard_blob is None
     assert data.raw_standard_xml is None
-    assert data.raw_quality_series is None
+    assert data.raw_quality_series.empty
     assert data.raw_quality_blob is None
     assert data.raw_quality_xml is None
-    assert data.raw_check_data is None
-    assert data.raw_check_series is None
+    assert data.raw_check_data.empty
     assert data.raw_check_blob is None
     assert data.raw_check_xml is None
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,89 @@
+"""Test the filters module."""
+
+import pandas as pd
+import pytest
+
+import hydrobot.utils as utils
+
+mowsecs_data_dict = {
+    "2619302400": 42,
+    "2619302700": 42,
+    "2619303000": 42,
+    "2619303300": 42,
+    "2619303600": 42,
+    "2619303900": 42,
+    "2619304200": 42,
+    "2619304500": 42,
+    "2619304800": 42,
+    "2619305100": 42,
+}
+
+datetime_data_dict = {
+    "2023-01-01 00:00:00": 42,
+    "2023-01-01 00:05:00": 42,
+    "2023-01-01 00:10:00": 42,
+    "2023-01-01 00:15:00": 42,
+    "2023-01-01 00:20:00": 42,
+    "2023-01-01 00:25:00": 42,
+    "2023-01-01 00:30:00": 42,
+    "2023-01-01 00:35:00": 42,
+    "2023-01-01 00:40:00": 42,
+    "2023-01-01 00:45:00": 42,
+}
+
+
+@pytest.fixture()
+def mowsecs_data():
+    """Get example data for testing.
+
+    Do not change these values!
+    """
+    # Allows parametrization with a list of keys to change to np.nan
+    return pd.Series(mowsecs_data_dict)
+
+
+@pytest.fixture()
+def datetime_data():
+    """Get example data for testing.
+
+    Do not change these values!
+    """
+    # Allows parametrization with a list of keys to change to np.nan
+    data = pd.Series(datetime_data_dict)
+    data.index = pd.to_datetime(data.index)
+    return data
+
+
+def test_mowsecs_to_timestamp(mowsecs_data, datetime_data):
+    """Test mowsecs_to_datetime_index utility."""
+    for mowsec, timestamp in zip(mowsecs_data.index.values, datetime_data.index.values):
+        ms_to_dt = utils.mowsecs_to_timestamp(mowsec)
+        assert ms_to_dt == timestamp
+
+        str_ms_to_dt = utils.mowsecs_to_timestamp(str(mowsec))
+        assert str_ms_to_dt == timestamp
+
+        float_ms_to_dt = utils.mowsecs_to_timestamp(float(mowsec))
+        assert float_ms_to_dt == timestamp
+
+
+def test_timestamp_to_mowsecs(mowsecs_data, datetime_data):
+    """Test mowsecs_to_datetime_index utility."""
+    for timestamp, mowsec in zip(datetime_data.index.values, mowsecs_data.index.values):
+        dt_to_ms = utils.timestamp_to_mowsecs(timestamp)
+
+        assert dt_to_ms == int(mowsec)
+
+
+def test_mowsecs_to_datetime_index(mowsecs_data, datetime_data):
+    """Test mowsecs_to_datetime_index utility."""
+    ms_to_dt = utils.mowsecs_to_datetime_index(mowsecs_data.index)
+
+    assert ms_to_dt.equals(datetime_data.index)
+
+
+def test_datetime_index_to_mowsecs(mowsecs_data, datetime_data):
+    """Test mowsecs_to_datetime_index utility."""
+    dt_to_ms = utils.datetime_index_to_mowsecs(datetime_data.index)
+
+    assert dt_to_ms.equals(mowsecs_data.index.astype(int))

--- a/tests/test_xml_data_structure.py
+++ b/tests/test_xml_data_structure.py
@@ -249,7 +249,7 @@ def test_data_source_to_xml_tree(tmp_path, sample_data_source_xml_file):
 
     blob_list = xml_data_structure.parse_xml(sample_data_source_xml)
 
-    output_path = tmp_path / "output.xml"
+    output_path = "output.xml"
     xml_data_structure.write_hilltop_xml(blob_list, output_path)
 
     with open(output_path) as f:

--- a/tests/test_xml_data_structure.py
+++ b/tests/test_xml_data_structure.py
@@ -249,7 +249,7 @@ def test_data_source_to_xml_tree(tmp_path, sample_data_source_xml_file):
 
     blob_list = xml_data_structure.parse_xml(sample_data_source_xml)
 
-    output_path = "output.xml"
+    output_path = tmp_path / "output.xml"
     xml_data_structure.write_hilltop_xml(blob_list, output_path)
 
     with open(output_path) as f:

--- a/tests/xml_test_data_file.xml
+++ b/tests/xml_test_data_file.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" ?>
+<?xml version='1.0' encoding='utf-8'?>
 <Hilltop>
     <Agency>Horizons</Agency>
     <Measurement SiteName="Mid Stream at Cowtoilet Farm">
@@ -16,16 +16,46 @@
             </ItemInfo>
         </DataSource>
         <Data DateFormat="mowsecs" NumItems="1">
-            <V>2619302400 10</V>
-            <V>2619302700 9</V>
-            <V>2619303000 8</V>
-            <V>2619303300 10</V>
-            <V>2619303600 10</V>
-            <V>2619303900 9</V>
-            <V>2619304200 10</V>
-            <V>2619304500 6</V>
-            <V>2619304800 10</V>
-            <V>2619305100 10</V>
+            <E>
+                <T>2619302400</T>
+                <I1>10</I1>
+            </E>
+            <E>
+                <T>2619302700</T>
+                <I1>9</I1>
+            </E>
+            <E>
+                <T>2619303000</T>
+                <I1>8</I1>
+            </E>
+            <E>
+                <T>2619303300</T>
+                <I1>10</I1>
+            </E>
+            <E>
+                <T>2619303600</T>
+                <I1>10</I1>
+            </E>
+            <E>
+                <T>2619303900</T>
+                <I1>9</I1>
+            </E>
+            <E>
+                <T>2619304200</T>
+                <I1>10</I1>
+            </E>
+            <E>
+                <T>2619304500</T>
+                <I1>6</I1>
+            </E>
+            <E>
+                <T>2619304800</T>
+                <I1>10</I1>
+            </E>
+            <E>
+                <T>2619305100</T>
+                <I1>10</I1>
+            </E>
         </Data>
     </Measurement>
     <Measurement SiteName="Mid Stream at Cowtoilet Farm">
@@ -36,7 +66,10 @@
             <ItemFormat>0</ItemFormat>
         </DataSource>
         <Data DateFormat="mowsecs" NumItems="1">
-            <V>2619302400 500</V>
+            <E>
+                <T>2619302400</T>
+                <I1>500</I1>
+            </E>
         </Data>
     </Measurement>
     <Measurement SiteName="Mid Stream at Cowtoilet Farm">
@@ -56,14 +89,14 @@
                 <ItemName>Recorder Time</ItemName>
                 <ItemFormat>D</ItemFormat>
                 <Divisor>1</Divisor>
-                <Units></Units>
+                <Units />
                 <Format>###</Format>
             </ItemInfo>
             <ItemInfo ItemNumber="3">
                 <ItemName>Comment</ItemName>
                 <ItemFormat>S</ItemFormat>
                 <Divisor>1</Divisor>
-                <Units></Units>
+                <Units />
                 <Format>###</Format>
             </ItemInfo>
         </DataSource>
@@ -115,16 +148,46 @@
             </ItemInfo>
         </DataSource>
         <Data DateFormat="mowsecs" NumItems="1">
-            <V>2619302400 174.3</V>
-            <V>2619302700 7.4</V>
-            <V>2619303000 1882.1</V>
-            <V>2619303300 12.4</V>
-            <V>2619303600 104.0</V>
-            <V>2619303900 1145.0</V>
-            <V>2619304200 6234.6</V>
-            <V>2619304500 6.1</V>
-            <V>2619304800 9991.0</V>
-            <V>2619305100 4.0</V>
+            <E>
+                <T>2619302400</T>
+                <I1>174.3</I1>
+            </E>
+            <E>
+                <T>2619302700</T>
+                <I1>7.4</I1>
+            </E>
+            <E>
+                <T>2619303000</T>
+                <I1>1882.1</I1>
+            </E>
+            <E>
+                <T>2619303300</T>
+                <I1>12.4</I1>
+            </E>
+            <E>
+                <T>2619303600</T>
+                <I1>104.0</I1>
+            </E>
+            <E>
+                <T>2619303900</T>
+                <I1>1145.0</I1>
+            </E>
+            <E>
+                <T>2619304200</T>
+                <I1>6234.6</I1>
+            </E>
+            <E>
+                <T>2619304500</T>
+                <I1>6.1</I1>
+            </E>
+            <E>
+                <T>2619304800</T>
+                <I1>9991.0</I1>
+            </E>
+            <E>
+                <T>2619305100</T>
+                <I1>4.0</I1>
+            </E>
         </Data>
     </Measurement>
     <Measurement SiteName="Mid Stream at Cowtoilet Farm">
@@ -135,7 +198,10 @@
             <ItemFormat>0</ItemFormat>
         </DataSource>
         <Data DateFormat="mowsecs" NumItems="1">
-            <V>2619302400 200</V>
+            <E>
+                <T>2619302400</T>
+                <I1>200</I1>
+            </E>
         </Data>
     </Measurement>
     <Measurement SiteName="Mid Stream at Cowtoilet Farm">
@@ -155,21 +221,21 @@
                 <ItemName>Recorder Time</ItemName>
                 <ItemFormat>D</ItemFormat>
                 <Divisor>0</Divisor>
-                <Units></Units>
+                <Units />
                 <Format>###</Format>
             </ItemInfo>
             <ItemInfo ItemNumber="3">
                 <ItemName>Handheld Turdidity Sensor Reading</ItemName>
                 <ItemFormat>F</ItemFormat>
                 <Divisor>1</Divisor>
-                <Units></Units>
+                <Units />
                 <Format>###.#</Format>
             </ItemInfo>
             <ItemInfo ItemNumber="4">
                 <ItemName>Comment</ItemName>
                 <ItemFormat>S</ItemFormat>
                 <Divisor>1</Divisor>
-                <Units></Units>
+                <Units />
                 <Format>###</Format>
             </ItemInfo>
         </DataSource>
@@ -223,16 +289,46 @@
             </ItemInfo>
         </DataSource>
         <Data DateFormat="mowsecs" NumItems="1">
-            <V>2619302400 1</V>
-            <V>2619302700 7</V>
-            <V>2619303000 1</V>
-            <V>2619303300 1</V>
-            <V>2619303600 1</V>
-            <V>2619303900 1</V>
-            <V>2619304200 6</V>
-            <V>2619304500 6</V>
-            <V>2619304800 9</V>
-            <V>2619305100 4</V>
+            <E>
+                <T>2619302400</T>
+                <I1>1</I1>
+            </E>
+            <E>
+                <T>2619302700</T>
+                <I1>7</I1>
+            </E>
+            <E>
+                <T>2619303000</T>
+                <I1>1</I1>
+            </E>
+            <E>
+                <T>2619303300</T>
+                <I1>1</I1>
+            </E>
+            <E>
+                <T>2619303600</T>
+                <I1>1</I1>
+            </E>
+            <E>
+                <T>2619303900</T>
+                <I1>1</I1>
+            </E>
+            <E>
+                <T>2619304200</T>
+                <I1>6</I1>
+            </E>
+            <E>
+                <T>2619304500</T>
+                <I1>6</I1>
+            </E>
+            <E>
+                <T>2619304800</T>
+                <I1>9</I1>
+            </E>
+            <E>
+                <T>2619305100</T>
+                <I1>4</I1>
+            </E>
         </Data>
     </Measurement>
     <Measurement SiteName="Mid Stream at Cowtoilet Farm">
@@ -243,7 +339,10 @@
             <ItemFormat>0</ItemFormat>
         </DataSource>
         <Data DateFormat="mowsecs" NumItems="1">
-            <V>2619302400 600</V>
+            <E>
+                <T>2619302399</T>
+                <I1>600</I1>
+            </E>
         </Data>
     </Measurement>
     <Measurement SiteName="Mid Stream at Cowtoilet Farm">
@@ -263,14 +362,14 @@
                 <ItemName>Recorder Time</ItemName>
                 <ItemFormat>D</ItemFormat>
                 <Divisor>1</Divisor>
-                <Units></Units>
+                <Units />
                 <Format>###</Format>
             </ItemInfo>
             <ItemInfo ItemNumber="3">
                 <ItemName>Comment</ItemName>
                 <ItemFormat>S</ItemFormat>
                 <Divisor>1</Divisor>
-                <Units></Units>
+                <Units />
                 <Format>###</Format>
             </ItemInfo>
         </DataSource>


### PR DESCRIPTION
- Resolves #53 by making the handling of export filenames a bit more consistent, except in the case of the hilltop_csv export, which necessarily creates two files.
- Fixes #52 by correctly handling gaps in xml import and export, now supports the <Gap/> tag. 
- Added the mowsecs conversion utils in, resolves #51.
- Fixed error handling on empty check data, fixes #45.
- Somewhat addresses #57 in that I believe all warnings are valid now, but I still need to handle expected warnings in the pytests.